### PR TITLE
[SREP-775] Build Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 *.so
 *.dylib
 
+rhobs-synthetics-api
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,21 @@
+# Makefile for building the rhobs-synthetics-api binary
 OAPI_CODEGEN_VERSION=v2.4.1
 
-# Default target
-all: generate
+# The name of the binary to be built
+BINARY_NAME=rhobs-synthetics-api
+
+# The main package of the application
+MAIN_PACKAGE=./cmd/api/main.go
+
+.PHONY: all build clean run help lint lint-ci tidy generate ensure-oapi-codegen
+
+all: build
+
+# Build the Go binary
+build:
+	@echo "Building $(BINARY_NAME)..."
+	@go build -o $(BINARY_NAME) $(MAIN_PACKAGE)
+	@echo "$(BINARY_NAME) built successfully."
 
 # Ensures oapi-codegen is installed locally.
 # It checks if the binary exists in GOPATH/bin, and if not, it installs it.
@@ -26,4 +40,11 @@ test:
 
 tidy:
 	go mod tidy
+
+# Clean up build artifacts
+clean:
+	@echo "Cleaning up..."
+	@go clean
+	@rm -f $(BINARY_NAME)
+	@echo "Cleanup complete."
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,15 @@ This application provides a synthetic monitoring API to be used within the RHOBS
 
 ---
 
-## 🚀 Getting Started
+## Building
+
+Build the `rhobs-synthetics-api` binary:
+
+```sh
+make build
+```
+
+## Running
 
 Run the API server locally using:
 ```sh


### PR DESCRIPTION
This adds `make` targets to ensure binary can be built locally. Updates to README.md to support local builds.

https://issues.redhat.com/browse/SREP-775