### PR TITLE
SREP-1440 Add Deployment Templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ MAIN_PACKAGE=./cmd/api/main.go
 CONTAINER_ENGINE ?= podman
 TESTOPTS ?= -cover
 
-.PHONY: all build clean run help lint lint-fix lint-ci go-mod-tidy go-mod-download generate ensure-oapi-codegen docker-build docker-push
+.PHONY: all build clean run help lint lint-fix lint-ci go-mod-tidy go-mod-download generate ensure-oapi-codegen docker-build docker-push test-templates
 
 all: build
 
@@ -61,6 +61,11 @@ $(GOLANGCI_LINT_BIN):
 
 test: go-mod-download
 	go test $(TESTOPTS) ./...
+
+# Test only the OpenShift templates
+test-templates:
+	@echo "Running template tests..."
+	go test $(TESTOPTS) ./templates/
 
 .PHONY: coverage
 coverage:

--- a/README.md
+++ b/README.md
@@ -225,3 +225,42 @@ curl -s -X PATCH -H "Content-Type: application/json" \
 ```
 $ curl -s -X DELETE http://localhost:8080/probes/176937a9-a1bb-4163-b602-a1416abe2f3c
 ```
+
+## OpenShift Deployment Templates
+
+This repository includes OpenShift templates for deploying the synthetics API in OpenShift environments:
+
+### Templates
+
+* `templates/synthetics-api-template.yaml` - Main deployment template containing:
+  - Service (headless service on port 11211)
+  - ServiceAccount
+  - StatefulSet with resource limits and requests
+
+* `templates/service-monitor-synthetics-api-template.yaml` - Prometheus monitoring template containing:
+  - ServiceMonitor for metrics collection on `/metrics` endpoint
+
+### Deploying with OpenShift Templates
+
+To deploy the synthetics API using the OpenShift templates:
+
+```sh
+# Deploy the main application
+oc process -f templates/synthetics-api-template.yaml \
+  -p IMAGE_TAG=latest \
+  -p NAMESPACE=rhobs | oc apply -f -
+
+# Deploy the service monitor for metrics
+oc process -f templates/service-monitor-synthetics-api-template.yaml \
+  -p NAMESPACE=rhobs | oc apply -f -
+```
+
+### Template Parameters
+
+**synthetics-api-template.yaml:**
+- `IMAGE_TAG` - Container image tag (default: latest)
+- `NAMESPACE` - Target namespace (default: rhobs)
+
+**service-monitor-synthetics-api-template.yaml:**
+- `IMAGE_TAG` - Container image tag (default: latest)
+- `NAMESPACE` - Target namespace for both the application and ServiceMonitor (default: rhobs)

--- a/templates/service-monitor-synthetics-api-template.yaml
+++ b/templates/service-monitor-synthetics-api-template.yaml
@@ -1,0 +1,38 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: synthetics-api-service-monitor
+objects:
+- apiVersion: monitoring.coreos.com/v1
+  kind: ServiceMonitor
+  metadata:
+    labels:
+      app.kubernetes.io/component: synthetics-api
+      app.kubernetes.io/instance: rhobs
+      app.kubernetes.io/name: synthetics-api
+      app.kubernetes.io/part-of: rhobs
+      app.kubernetes.io/version: ${IMAGE_TAG}
+      prometheus: app-sre
+    name: synthetics-api
+    namespace: ${NAMESPACE}
+  spec:
+    endpoints:
+    - honorLabels: true
+      interval: 30s
+      path: /metrics
+      port: metrics
+    namespaceSelector:
+      matchNames:
+      - ${NAMESPACE}
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: synthetics-api
+        app.kubernetes.io/instance: rhobs
+        app.kubernetes.io/name: synthetics-api
+        app.kubernetes.io/part-of: rhobs
+        app.kubernetes.io/version: ${IMAGE_TAG}
+parameters:
+- name: IMAGE_TAG
+  value: latest
+- name: NAMESPACE
+  value: rhobs

--- a/templates/synthetics-api-template.yaml
+++ b/templates/synthetics-api-template.yaml
@@ -1,0 +1,93 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: synthetics-api
+objects:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/component: synthetics-api
+      app.kubernetes.io/instance: rhobs
+      app.kubernetes.io/name: synthetics-api
+      app.kubernetes.io/part-of: rhobs
+      app.kubernetes.io/version: ${IMAGE_TAG}
+    name: synthetics-api
+    namespace: ${NAMESPACE}
+  spec:
+    clusterIP: None
+    ports:
+    - name: synthetics-api
+      port: 11211
+      protocol: TCP
+      targetPort: 11211
+    selector:
+      app.kubernetes.io/component: synthetics-api
+      app.kubernetes.io/instance: rhobs
+      app.kubernetes.io/name: synthetics-api
+      app.kubernetes.io/part-of: rhobs
+      app.kubernetes.io/version: ${IMAGE_TAG}
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    labels:
+      app.kubernetes.io/component: synthetics-api
+      app.kubernetes.io/instance: rhobs
+      app.kubernetes.io/name: synthetics-api
+      app.kubernetes.io/part-of: rhobs
+      app.kubernetes.io/version: ${IMAGE_TAG}
+    name: synthetics-api
+    namespace: ${NAMESPACE}
+- apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    labels:
+      app.kubernetes.io/component: synthetics-api
+      app.kubernetes.io/instance: rhobs
+      app.kubernetes.io/name: synthetics-api
+      app.kubernetes.io/part-of: rhobs
+      app.kubernetes.io/version: ${IMAGE_TAG}
+    name: synthetics-api
+    namespace: ${NAMESPACE}
+  spec:
+    podManagementPolicy: OrderedReady
+    replicas: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: synthetics-api
+        app.kubernetes.io/instance: rhobs
+        app.kubernetes.io/name: synthetics-api
+        app.kubernetes.io/part-of: rhobs
+        app.kubernetes.io/version: ${IMAGE_TAG}
+    serviceName: synthetics-api
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/component: synthetics-api
+          app.kubernetes.io/instance: rhobs
+          app.kubernetes.io/name: synthetics-api
+          app.kubernetes.io/part-of: rhobs
+          app.kubernetes.io/version: ${IMAGE_TAG}
+      spec:
+        containers:
+        - image: quay.io/redhat-services-prod/openshift/rhobs-synthetics-api:${IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
+          name: synthetics-api
+          ports:
+          - containerPort: 11211
+            name: synthetics-api
+            protocol: TCP
+          resources:
+            limits:
+              cpu: "1"
+              memory: 2Gi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          terminationMessagePolicy: FallbackToLogsOnError
+        serviceAccountName: synthetics-api
+parameters:
+- name: IMAGE_TAG
+  value: latest
+- name: NAMESPACE
+  value: rhobs

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -1,0 +1,189 @@
+package templates
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestTemplatesValidYAML(t *testing.T) {
+	templateFiles := []string{
+		"synthetics-api-template.yaml",
+		"service-monitor-synthetics-api-template.yaml",
+	}
+
+	for _, file := range templateFiles {
+		t.Run(file, func(t *testing.T) {
+			content, err := os.ReadFile(filepath.Join(".", file))
+			if err != nil {
+				t.Fatalf("Failed to read template file %s: %v", file, err)
+			}
+
+			var template map[string]interface{}
+			if err := yaml.Unmarshal(content, &template); err != nil {
+				t.Fatalf("Template %s is not valid YAML: %v", file, err)
+			}
+
+			// Verify it's an OpenShift template
+			if apiVersion, ok := template["apiVersion"].(string); !ok || apiVersion != "template.openshift.io/v1" {
+				t.Errorf("Template %s should have apiVersion 'template.openshift.io/v1', got %v", file, template["apiVersion"])
+			}
+
+			if kind, ok := template["kind"].(string); !ok || kind != "Template" {
+				t.Errorf("Template %s should have kind 'Template', got %v", file, template["kind"])
+			}
+
+			// Verify it has objects
+			if objects, ok := template["objects"].([]interface{}); !ok || len(objects) == 0 {
+				t.Errorf("Template %s should have non-empty objects array", file)
+			}
+		})
+	}
+}
+
+func TestSyntheticsAPITemplateStructure(t *testing.T) {
+	content, err := os.ReadFile("synthetics-api-template.yaml")
+	if err != nil {
+		t.Fatalf("Failed to read synthetics-api-template.yaml: %v", err)
+	}
+
+	var template map[string]interface{}
+	if err := yaml.Unmarshal(content, &template); err != nil {
+		t.Fatalf("Template is not valid YAML: %v", err)
+	}
+
+	objects, ok := template["objects"].([]interface{})
+	if !ok {
+		t.Fatal("Template should have objects array")
+	}
+
+	expectedKinds := map[string]bool{
+		"Service":     false,
+		"ServiceAccount": false,
+		"StatefulSet": false,
+	}
+
+	for _, obj := range objects {
+		objMap, ok := obj.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		if kind, ok := objMap["kind"].(string); ok {
+			if _, expected := expectedKinds[kind]; expected {
+				expectedKinds[kind] = true
+			}
+		}
+	}
+
+	for kind, found := range expectedKinds {
+		if !found {
+			t.Errorf("Expected to find %s object in template", kind)
+		}
+	}
+
+	// Verify parameters
+	params, ok := template["parameters"].([]interface{})
+	if !ok || len(params) == 0 {
+		t.Error("Template should have parameters")
+	}
+
+	// Verify IMAGE_DIGEST parameter is not present
+	for _, param := range params {
+		paramMap, ok := param.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if name, ok := paramMap["name"].(string); ok && name == "IMAGE_DIGEST" {
+			t.Error("IMAGE_DIGEST parameter should not be present in template")
+		}
+	}
+
+	// Verify NAMESPACE parameter is present
+	namespaceFound := false
+	imageTagFound := false
+	for _, param := range params {
+		paramMap, ok := param.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if name, ok := paramMap["name"].(string); ok {
+			if name == "NAMESPACE" {
+				namespaceFound = true
+			}
+			if name == "IMAGE_TAG" {
+				imageTagFound = true
+			}
+		}
+	}
+	if !namespaceFound {
+		t.Error("NAMESPACE parameter should be present in template")
+	}
+	if !imageTagFound {
+		t.Error("IMAGE_TAG parameter should be present in template")
+	}
+}
+
+func TestServiceMonitorTemplateStructure(t *testing.T) {
+	content, err := os.ReadFile("service-monitor-synthetics-api-template.yaml")
+	if err != nil {
+		t.Fatalf("Failed to read service-monitor-synthetics-api-template.yaml: %v", err)
+	}
+
+	var template map[string]interface{}
+	if err := yaml.Unmarshal(content, &template); err != nil {
+		t.Fatalf("Template is not valid YAML: %v", err)
+	}
+
+	objects, ok := template["objects"].([]interface{})
+	if !ok || len(objects) != 1 {
+		t.Fatal("Template should have exactly one object")
+	}
+
+	serviceMonitor, ok := objects[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("Object should be a map")
+	}
+
+	if kind, ok := serviceMonitor["kind"].(string); !ok || kind != "ServiceMonitor" {
+		t.Errorf("Expected ServiceMonitor object, got %v", serviceMonitor["kind"])
+	}
+
+	if apiVersion, ok := serviceMonitor["apiVersion"].(string); !ok || apiVersion != "monitoring.coreos.com/v1" {
+		t.Errorf("Expected apiVersion 'monitoring.coreos.com/v1', got %v", serviceMonitor["apiVersion"])
+	}
+
+	// Verify parameters
+	params, ok := template["parameters"].([]interface{})
+	if !ok || len(params) == 0 {
+		t.Error("Template should have parameters")
+	}
+
+	namespaceFound := false
+	imageTagFound := false
+	for _, param := range params {
+		paramMap, ok := param.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if name, ok := paramMap["name"].(string); ok {
+			if name == "NAMESPACE" {
+				namespaceFound = true
+			}
+			if name == "IMAGE_TAG" {
+				imageTagFound = true
+			}
+			if name == "MONITORING_NAMESPACE" {
+				t.Error("MONITORING_NAMESPACE parameter should not be present - should use NAMESPACE instead")
+			}
+		}
+	}
+	if !namespaceFound {
+		t.Error("NAMESPACE parameter should be present in service monitor template")
+	}
+	if !imageTagFound {
+		t.Error("IMAGE_TAG parameter should be present in service monitor template")
+	}
+}


### PR DESCRIPTION
Add OpenShift deployment templates with testing:
- Add synthetics-api-template.yaml with Service, ServiceAccount, and StatefulSet
- Add service-monitor-synthetics-api-template.yaml for Prometheus monitoring
- Include parameterized NAMESPACE and IMAGE_TAG for flexible deployment
- Add test suite for template validation
- Update README.md 