### PR TITLE
Fix namespace and port configuration for deployment

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -249,7 +249,7 @@ func main() {
 	startCmd.Flags().String("database-engine", "etcd", "Specifies the backend database engine. Supported: 'etcd', 'local'.")
 	startCmd.Flags().String("data-dir", "", "Directory for local storage (only valid with --database-engine=local, defaults to 'data')")
 	startCmd.Flags().String("kubeconfig", "", "Path to kubeconfig file (optional, for out-of-cluster development)")
-	startCmd.Flags().String("namespace", "default", "The Kubernetes namespace to store probe configmaps in.")
+	startCmd.Flags().String("namespace", "rhobs", "The Kubernetes namespace to store probe configmaps in.")
 
 	// Bind flags to viper
 	viper.BindPFlag("port", startCmd.Flags().Lookup("port")) //nolint:errcheck
@@ -262,6 +262,9 @@ func main() {
 	viper.BindPFlag("log_level", startCmd.Flags().Lookup("log-level")) //nolint:errcheck
 	viper.BindPFlag("kubeconfig", startCmd.Flags().Lookup("kubeconfig")) //nolint:errcheck
 	viper.BindPFlag("namespace", startCmd.Flags().Lookup("namespace")) //nolint:errcheck
+
+	// Bind environment variables to viper
+	viper.BindEnv("namespace", "NAMESPACE") //nolint:errcheck
 
 	// Add commands to the root command
 	rootCmd.AddCommand(startCmd)

--- a/templates/synthetics-api-template.yaml
+++ b/templates/synthetics-api-template.yaml
@@ -21,9 +21,9 @@ objects:
     ipFamilyPolicy: SingleStack
     ports:
     - name: synthetics-api
-      port: 11211
+      port: 8080
       protocol: TCP
-      targetPort: 11211
+      targetPort: 8080
     selector:
       app.kubernetes.io/component: synthetics-api
       app.kubernetes.io/instance: rhobs
@@ -77,8 +77,11 @@ objects:
         - image: quay.io/redhat-services-prod/openshift/rhobs-synthetics-api:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           name: synthetics-api
+          env:
+          - name: NAMESPACE
+            value: ${NAMESPACE}
           ports:
-          - containerPort: 11211
+          - containerPort: 8080
             name: synthetics-api
             protocol: TCP
           resources:


### PR DESCRIPTION
Fix namespace and port configuration for deployment
- Update default namespace from 'default' to 'rhobs' to match template
- Add NAMESPACE environment variable binding to use deployment namespace
- Fix container and service ports from 11211 to 8080
- Ensure probe store initializes in same namespace as API deployment

[SREP-1201](https://issues.redhat.com//browse/SREP-1201)