### PR TITLE
Optimize StatefulSet for faster rollouts and fix port documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ This repository includes OpenShift templates for deploying the synthetics API in
 ### Templates
 
 * `templates/synthetics-api-template.yaml` - Main deployment template containing:
-  - Service (headless service on port 11211)
+  - Service (service on port 8080)
   - ServiceAccount
   - StatefulSet with resource limits and requests
 

--- a/templates/synthetics-api-template.yaml
+++ b/templates/synthetics-api-template.yaml
@@ -88,7 +88,7 @@ objects:
     name: synthetics-api
     namespace: ${NAMESPACE}
   spec:
-    podManagementPolicy: OrderedReady
+    podManagementPolicy: Parallel
     replicas: 1
     selector:
       matchLabels:
@@ -118,6 +118,20 @@ objects:
           - containerPort: 8080
             name: synthetics-api
             protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
           resources:
             limits:
               cpu: "1"
@@ -127,6 +141,7 @@ objects:
               memory: 100Mi
           terminationMessagePolicy: FallbackToLogsOnError
         serviceAccountName: synthetics-api
+        terminationGracePeriodSeconds: 30
 parameters:
 - name: IMAGE_TAG
   value: latest


### PR DESCRIPTION
Optimize StatefulSet for faster rollouts and fix port documentation
- Change podManagementPolicy to Parallel for faster deployments
- Add health probes (readiness and liveness) for rapid pod readiness detection
- Set terminationGracePeriodSeconds to 30 for quicker shutdown
- Fix README port reference from 11211 to 8080

SREP-1201