### PR TITLE
Fix StatefulSet rollout failure by removing volume configuration

### DIFF
--- a/templates/synthetics-api-template.yaml
+++ b/templates/synthetics-api-template.yaml
@@ -132,30 +132,8 @@ objects:
               cpu: 100m
               memory: 100Mi
           terminationMessagePolicy: FallbackToLogsOnError
-          volumeMounts:
-          - name: api-data
-            mountPath: /data
         serviceAccountName: synthetics-api
         terminationGracePeriodSeconds: 30
-  volumeClaimTemplates:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
-      name: api-data
-      namespace: ${NAMESPACE}
-      labels:
-        app.kubernetes.io/component: synthetics-api
-        app.kubernetes.io/instance: rhobs
-        app.kubernetes.io/name: synthetics-api
-        app.kubernetes.io/part-of: rhobs
-    spec:
-      accessModes:
-      - ReadWriteOnce
-      resources:
-        requests:
-          storage: 1Gi
-      storageClassName: gp2
-      volumeMode: Filesystem
 parameters:
 - name: IMAGE_TAG
   value: latest


### PR DESCRIPTION
Fix StatefulSet rollout failure by removing volume configuration
- Remove volumeMounts and volumeClaimTemplates causing pod creation failures
- StatefulSet volumeClaimTemplates field is immutable and was missing from deployed resource
- Application uses etcd mode (ConfigMaps) so persistent storage not needed
- Resolves "api-data volume not found" error preventing pod startup