### PR TITLE
Update API to be deployed as a "deployment"

### DIFF
--- a/templates/synthetics-api-template.yaml
+++ b/templates/synthetics-api-template.yaml
@@ -72,7 +72,7 @@ objects:
     name: synthetics-api
     namespace: ${NAMESPACE}
 - apiVersion: apps/v1
-  kind: StatefulSet
+  kind: Deployment
   metadata:
     labels:
       app.kubernetes.io/component: synthetics-api
@@ -82,15 +82,18 @@ objects:
     name: synthetics-api
     namespace: ${NAMESPACE}
   spec:
-    podManagementPolicy: Parallel
     replicas: 1
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 25%
+        maxSurge: 25%
     selector:
       matchLabels:
         app.kubernetes.io/component: synthetics-api
         app.kubernetes.io/instance: rhobs
         app.kubernetes.io/name: synthetics-api
         app.kubernetes.io/part-of: rhobs
-    serviceName: synthetics-api
     template:
       metadata:
         labels:

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -60,9 +60,9 @@ func TestSyntheticsAPITemplateStructure(t *testing.T) {
 	}
 
 	expectedKinds := map[string]bool{
-		"Service":     false,
+		"Service":        false,
 		"ServiceAccount": false,
-		"StatefulSet": false,
+		"Deployment":     false,
 	}
 
 	for _, obj := range objects {


### PR DESCRIPTION
# Overview

In [SREP-798](https://issues.redhat.com/browse/SREP-798) it was called out the API pods should be deployed as a `Deployment` so we can add a `HorizontalPodAutoscaler` in the future if we find we need the workload to scale with demand. 

This change updates the template used to deploy the API service so that we're deploying a `Deployment` instead of a `StatefulSet`. (FYI: There is no state required for the API, and we can run multiple replicas without issue).

# Notes
* I suspect we'll have to do some manual cleanup of the previously deployed resources. I'll take care of that audit after this PR is merged and deployed. 