### PR TITLE
Fix bug with DELETE logic

### DIFF
--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -222,6 +222,7 @@ components:
         - active
         - failed
         - terminating
+        - deleted
       example: active
 
     ErrorObject:

--- a/go.mod
+++ b/go.mod
@@ -63,10 +63,10 @@ require (
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
-	golang.org/x/net v0.38.0 // indirect
+	golang.org/x/net v0.41.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
-	golang.org/x/sys v0.31.0 // indirect
-	golang.org/x/term v0.30.0 // indirect
+	golang.org/x/sys v0.33.0 // indirect
+	golang.org/x/term v0.32.0 // indirect
 	golang.org/x/text v0.27.0 // indirect
 	golang.org/x/time v0.9.0 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -151,8 +151,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
-golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/net v0.41.0 h1:vBTly1HeNPEn3wtREYfy4GZ/NECgw2Cnl+nK6Nz3uvw=
+golang.org/x/net v0.41.0/go.mod h1:B/K4NNqkfmg07DQYrbwvSluqCJOOXwUjeb/5lOisjbA=
 golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
 golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -161,10 +161,10 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
-golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
-golang.org/x/term v0.30.0 h1:PQ39fJZ+mfadBm0y5WlL4vlM7Sx1Hgf13sMIY2+QS9Y=
-golang.org/x/term v0.30.0/go.mod h1:NYYFdzHoI5wRh/h5tDMdMqCqPJZEuNqVR5xJLd/n67g=
+golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
+golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/term v0.32.0 h1:DR4lr0TjUs3epypdhTOkMmuF5CDFJ/8pOnbzMZPQ7bg=
+golang.org/x/term v0.32.0/go.mod h1:uZG1FhGx848Sqfsq4/DlJr3xGGsYMu/L5GW4abiaEPQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.27.0 h1:4fGWRpyh641NLlecmyl4LOe6yDdfaYNrGb2zdfo4JV4=

--- a/internal/probestore/kubernetes.go
+++ b/internal/probestore/kubernetes.go
@@ -203,6 +203,14 @@ func (k *KubernetesProbeStore) DeleteProbe(ctx context.Context, probeID uuid.UUI
 	return nil
 }
 
+func (k *KubernetesProbeStore) DeleteProbeStorage(ctx context.Context, probeID uuid.UUID) error {
+	configMapName := fmt.Sprintf(probeConfigMapNameFormat, probeID)
+
+	// TODO: Tune logging level for this
+	log.Printf("Deleting probe configmap: %s", probeID.String())
+	return k.Client.CoreV1().ConfigMaps(k.Namespace).Delete(ctx, configMapName, metav1.DeleteOptions{})
+}
+
 func (k *KubernetesProbeStore) ProbeWithURLHashExists(ctx context.Context, urlHashString string) (bool, error) {
 	hashLabelSelector := fmt.Sprintf("%s=%s", probeURLHashLabelKey, urlHashString)
 	existingProbes, err := k.Client.CoreV1().ConfigMaps(k.Namespace).List(ctx, metav1.ListOptions{

--- a/internal/probestore/local_delete_test.go
+++ b/internal/probestore/local_delete_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	v1 "github.com/rhobs/rhobs-synthetics-api/pkg/apis/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -22,7 +23,7 @@ func TestLocalProbeStore_DeleteProbe(t *testing.T) {
 		checkErr   func(t *testing.T, err error)
 	}{
 		{
-			name:       "successfully deletes existing probe",
+			name:       "successfully sets probe status to terminating",
 			setupProbe: true,
 			probeID:    uuid.New(),
 			expectErr:  false,
@@ -75,9 +76,10 @@ func TestLocalProbeStore_DeleteProbe(t *testing.T) {
 				}
 			} else {
 				require.NoError(t, err)
-				// Verify the probe was actually deleted
-				_, err = store.GetProbe(ctx, tc.probeID)
-				assert.True(t, k8serrors.IsNotFound(err))
+				// Verify the probe status was set to terminating
+				probe, err := store.GetProbe(ctx, tc.probeID)
+				require.NoError(t, err, "Probe should still exist")
+				assert.Equal(t, v1.Terminating, probe.Status, "Probe status should be set to terminating")
 			}
 		})
 	}

--- a/internal/probestore/probestore.go
+++ b/internal/probestore/probestore.go
@@ -14,5 +14,6 @@ type ProbeStorage interface {
 	CreateProbe(ctx context.Context, probe v1.ProbeObject, urlHashString string) (*v1.ProbeObject, error)
 	UpdateProbe(ctx context.Context, probe v1.ProbeObject) (*v1.ProbeObject, error)
 	DeleteProbe(ctx context.Context, probeID uuid.UUID) error
+	DeleteProbeStorage(ctx context.Context, probeID uuid.UUID) error
 	ProbeWithURLHashExists(ctx context.Context, urlHashString string) (bool, error)
 }

--- a/pkg/apis/v1/types.go
+++ b/pkg/apis/v1/types.go
@@ -26,6 +26,7 @@ import (
 // Defines values for StatusSchema.
 const (
 	Active      StatusSchema = "active"
+	Deleted     StatusSchema = "deleted"
 	Failed      StatusSchema = "failed"
 	Pending     StatusSchema = "pending"
 	Terminating StatusSchema = "terminating"
@@ -746,17 +747,17 @@ var swaggerSpec = []string{
 	"mWBO6UVaG09sdKIWhRW0cujZaCaRePwml4iev+jDy4V7youF22MVntQGiM2m1/vk4I6tFev9JRj02eMf",
 	"9BrxjkJppRfMaGBkIMbWSQkneW0rhMw9KQdnG3gVXkEHdQKtYPWFtctsr84DR+zq4hMV5ryCLNuiXiLm",
 	"bjoaiVwNq18HVWkOE2OGElZuqRIcGrtoidsz39F2K3O9qOLCWtDIQtJavdUj00Xmgwctac+IixjVihp+",
-	"IlQKvqLAZkoLpOfXzWA2Szu4rnLZ0wPb6H5SkEo/sBR+NblA7QvdevtOJXdS+buwpK0DNzemtFSxp8jz",
-	"a8GZwsbA7oRj2iBLTKF3pODZYXcKlzT0vLivPoOeP/XnxXavv9UjKxL2l+hdWPAY3W0ydxHUm3QR0Eql",
-	"E9ND8/nM6yATWiyIzZNUxF/n5p4Fa6GwFXr+Ln4+O7lkl2uNS0AVu2oFOz6f8YivwLqw5Xg4Hk4oapOD",
-	"FrniU/6/4WToG5zApY93tPWkBXhZEBve+mfUMD8phxsAzSH+cz9B2yWjfUN+eU1shQT4g1+Ox75RG42g",
-	"PQaR56lXldGjL46CefiWCXXHhz3ru6Ku7xEiTTcdD+RmhCgjfnRAWO3ZrAdQPRbaYBpsy+PQy8sVWSbs",
-	"mk/5R0Am/ho+aUUsXNPby4jnxvUkuDG0V9cCcHhi5PpgsfdcC8p2xdCQVXZEMTmsKM4aJdjmPvhR7GFK",
-	"5oo4BueSIk3XlQ7ePZ8Ojqt+792RDNWJrO6wNIUwkZIRrxncK4dBqK+eV6gIVgu6utgV2NANdjUaUk6T",
-	"pYa7EFGfJsuo9p/RQ303LYM1poDQFeup/70W67fZUecW3uNDR11fDuIIgHbEwX4xrCK9EsrRwfKw26j2",
-	"yrbRY9s5CFy5zYUjExgvqbHk1qyUBMlmp/1G0dsIPkLoAyfrmfxHuB8/V7l/2LHLLTPVgFiz8wMmNZh/",
-	"gD1fM4VubxZziqqbx8aAeqg0Hr5l9EzRT2oZ4+dtGWF8720ZP8ro8KMJOGTWPU3E/h4Tfty15bNa1I5Z",
-	"SH0W0LAM0NJAvBmDmv/4dLy8Lv8MAAD//5xUgo+YFgAA",
+	"IlQKvqLAZkoLDM8lpIAgiadtWJuXOgivctnTDds4f1KQSj+6FH41+UHtEN3K+05Nd5L6u7CksgO3Oaa0",
+	"VLEnyzNtwZnCxsDuhGPaIEtMoXdE4dlhdwqXNP68uK8+g54/9efFdq+/1S0rEvYX611Y8BjdbTJ3EdSb",
+	"dBHQSqUT00Pz+czrIBNaLIjNk1TEX+fmngWTobAVev4ufj47uWSXa41LQBW7agU7Pp/xiK/AurDleDge",
+	"Tihqk4MWueJT/r/hZOhbncClj3e0dacFeFkQG74JzKh1flIONwCa4/znfoK2S0b7xv3ymtgKCfAHvxyP",
+	"fcs2GkF7DCLPU68qo0dfHAXz8C2z6o4je9Z3RV3fKESabnofyM0wUUb86ICw2lNaD6B6QLTBNNiWx6GX",
+	"lyuyTNg1n/KPgEz8NXzSili4psuXEc+N60lwY3yvLgjg8MTI9cFi77kglO2KoXGr7IhiclhRnDVKsM19",
+	"8KPYw5TMFXEMziVFmq4rHbx7Ph0cV53fuyMZqhNZ3WtpHmEiJSNeM7hXDoNQXz2vUBGsFnSJsSuwoRvs",
+	"ajSknGZMDXchoj5NllHtP6OH+pZaBmukptsV66n/vRbrt9lR5z7e40NHXV8O4qimgLY42C+GVaRXQjk6",
+	"WB52G9Ve2TZ6bDsHgSu3uXpkAuMlNZbcmpWSINnstN8oehvBRwh94GQ9k/8I9+PnKvcPO3a5ZaYaFWt2",
+	"fsCkBvMPsOdrptDtzWJOUXXz2BhQD5XGw7eMnin6SS1j/LwtI4zvvS3jRxkdfjQBh8y6p4nY32PCj7u2",
+	"fFaL2jELqc8CGpYBWhqIN2NQ81+gjpfX5Z8BAAD//0H5eeCiFgAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file


### PR DESCRIPTION
# Overview 

In https://github.com/rhobs/rhobs-synthetics-api/pull/91 we improved the `DELETE` logic to protect against orphaned probe resources - but made a mistake and forgot that the Synthetic Agent does a `DELETE` to cleanup things after it completes it's own cleanup. This introduced a bug where the agent could never signal to the API that the cleanup completed.

This change adds a new status `deleted` that has special logic to delete the API's data for a given probe when that status is used. This makes it so the agent can now PATCH `{status = 'deleted'}` to complete the deletion logic. 