### PR TITLE
Fix Makefile parsing error with multi-path GOPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ generate: ensure-oapi-codegen
 	$(GOENV) go generate -v ./...
 
 GOLANGCI_LINT_VERSION ?= v2.0.2
-GOLANGCI_LINT_BIN := $(shell go env GOPATH)/bin/golangci-lint
+# Extract first component of GOPATH (in case it has multiple colon-separated paths)
+GOLANGCI_LINT_BIN := $(shell echo $$(go env GOPATH) | cut -d: -f1)/bin/golangci-lint
 
 lint: $(GOLANGCI_LINT_BIN)
 	$(GOLANGCI_LINT_BIN) run ./...


### PR DESCRIPTION
## Summary
Fixes Make parsing error when `GOPATH` contains multiple colon-separated paths (common with gvm pkgsets).

The Makefile now extracts only the first component of `GOPATH`, which:
- Avoids Make interpreting colons as pattern rule delimiters
- Points to the correct location where `go install` puts binaries
- Works with both single-path and multi-path `GOPATH` configurations

## Test plan
- [x] Verified `make build` works with multi-path GOPATH
- [x] Verified `make lint` target parses correctly
- [x] Tested with single-path GOPATH (still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)