### PR TITLE
ROSAENG-60066: add post-deploy smoke test template

### DIFF
--- a/test/smoke-template.yaml
+++ b/test/smoke-template.yaml
@@ -1,0 +1,85 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: synthetics-api-smoke-check
+parameters:
+  - name: API_URL
+    required: true
+    description: Synthetics API service URL (e.g. http://synthetics-api.rhobs-int.svc:8080)
+  - name: JOBID
+    generate: expression
+    from: "[0-9a-z]{7}"
+  - name: IMAGE_TAG
+    value: ""
+    required: true
+objects:
+  - apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: synthetics-api-smoke-${IMAGE_TAG}-${JOBID}
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 300
+      template:
+        spec:
+          automountServiceAccountToken: false
+          restartPolicy: Never
+          containers:
+            - name: smoke-check
+              image: quay.io/openshift/origin-tools:latest
+              command:
+                - /bin/bash
+                - -ceu
+                - |
+                  FAILURES=0
+                  log() { echo "$(date +%H:%M:%S) $*"; }
+
+                  log "Synthetics API smoke check"
+                  log "  API URL: ${API_URL}"
+                  echo ""
+
+                  log "--- API Probes Endpoint ---"
+                  PROBES=$(curl -sfSL --retry 3 --retry-delay 5 --max-time 10 "${API_URL}/probes" 2>/dev/null)
+                  if [[ -z "$PROBES" ]]; then
+                    log "FAIL  /probes: no response"
+                    FAILURES=$((FAILURES + 1))
+                  else
+                    PROBE_COUNT=$(echo "$PROBES" | jq '. | length')
+                    if [[ "$PROBE_COUNT" -eq 0 ]]; then
+                      log "WARN  /probes: empty (0 probes)"
+                    else
+                      log "PASS  /probes: ${PROBE_COUNT} probes"
+                    fi
+                  fi
+
+                  echo ""
+                  log "--- API Metrics Endpoint ---"
+                  METRICS=$(curl -sfSL --retry 3 --retry-delay 5 --max-time 10 "${API_URL}/metrics" 2>/dev/null)
+                  if [[ -z "$METRICS" ]]; then
+                    log "FAIL  /metrics: no response"
+                    FAILURES=$((FAILURES + 1))
+                  else
+                    if echo "$METRICS" | grep -q "promhttp_metric_handler"; then
+                      log "PASS  /metrics: responding"
+                    else
+                      log "FAIL  /metrics: unexpected response"
+                      FAILURES=$((FAILURES + 1))
+                    fi
+                  fi
+
+                  echo ""
+                  if [[ $FAILURES -gt 0 ]]; then
+                    log "FAILED: $FAILURES check(s) failed"
+                    exit 1
+                  fi
+                  log "PASSED: all checks passed"
+              env:
+                - name: API_URL
+                  value: ${API_URL}
+              resources:
+                requests:
+                  cpu: "50m"
+                  memory: "64Mi"
+                limits:
+                  cpu: "200m"
+                  memory: "128Mi"


### PR DESCRIPTION
## Summary

Add a post-deploy smoke test OpenShift Template (`test/smoke-template.yaml`) for SAPM gating.

The template runs as a Job on RHOBS cells after deployment and verifies:
- `/probes` returns data
- `/metrics` endpoint responds with expected Prometheus metrics

Used by app-interface saas files to gate promotion of synthetics-api to production. The template lives in this repo so the SAPM subscriber and publisher share the same source repository (required by SAPM validation).

Jira: https://redhat.atlassian.net/browse/ROSAENG-60066