### PR TITLE
ROSAENG-62776: add NetworkPolicy to restrict synthetics-api ingress

### DIFF
--- a/templates/synthetics-api-template.yaml
+++ b/templates/synthetics-api-template.yaml
@@ -71,6 +71,41 @@ objects:
   - kind: ServiceAccount
     name: synthetics-api
     namespace: ${NAMESPACE}
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      app.kubernetes.io/component: synthetics-api
+      app.kubernetes.io/instance: rhobs
+      app.kubernetes.io/name: synthetics-api
+      app.kubernetes.io/part-of: rhobs
+    name: synthetics-api
+    namespace: ${NAMESPACE}
+  spec:
+    podSelector:
+      matchLabels:
+        app.kubernetes.io/name: synthetics-api
+    policyTypes:
+    - Ingress
+    ingress:
+    - from:
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/name: synthetics-agent
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/name: rhobs-gateway
+      ports:
+      - protocol: TCP
+        port: 8080
+    - from:
+      - namespaceSelector: {}
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/name: prometheus
+      ports:
+      - protocol: TCP
+        port: 8080
 - apiVersion: apps/v1
   kind: Deployment
   metadata:

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -63,6 +63,7 @@ func TestSyntheticsAPITemplateStructure(t *testing.T) {
 		"Service":        false,
 		"ServiceAccount": false,
 		"Deployment":     false,
+		"NetworkPolicy":  false,
 	}
 
 	for _, obj := range objects {


### PR DESCRIPTION
## Summary

- Adds a `NetworkPolicy` to the deployment template that restricts ingress to synthetics-api on port 8080
- Only allows traffic from `synthetics-agent`, `rhobs-gateway`, and `prometheus` pods
- All other in-cluster traffic is denied by default
- Updates template test to verify the NetworkPolicy object is present

This addresses the Glasswing security finding ([ROSAENG-62776](https://redhat.atlassian.net/browse/ROSAENG-62776)) that no NetworkPolicy was shipped, allowing any pod in the cluster to reach the API. Also partially mitigates [ROSAENG-62775](https://redhat.atlassian.net/browse/ROSAENG-62775) (no authn/authz) by restricting the in-cluster attack surface to only authorized callers.

External access is already protected by the obs-api gateway (OIDC + RBAC).

**Note:** A corresponding app-interface MR is needed to add `NetworkPolicy` to `managedResourceTypes` in `saas-synthetics-api.yaml`.

## Test plan

- [ ] `go test ./templates/` passes (verifies NetworkPolicy object in template)
- [ ] `go test ./...` passes (no regressions)
- [ ] Verify in integration that synthetics-agent can still reach synthetics-api
- [ ] Verify in integration that obs-api gateway can still reach synthetics-api
- [ ] Verify in integration that prometheus can still scrape /metrics
- [ ] Verify that an arbitrary pod in the namespace cannot reach synthetics-api